### PR TITLE
Temat_9 Zastosowanie Explicit Waitów w testach

### DIFF
--- a/src/test/java/JavaStartSeleniumRozdzial_9/driver/manager/DriverUtils.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/driver/manager/DriverUtils.java
@@ -1,12 +1,9 @@
 package JavaStartSeleniumRozdzial_9.driver.manager;
 
-import java.time.Duration;
-
 
 public class DriverUtils {
 
     public static void setInitialConfiguration() {
-        DriverManager.getWebDriver().manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
         DriverManager.getWebDriver().manage().window().maximize();
     }
 

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/FooterPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/FooterPage.java
@@ -1,6 +1,7 @@
 package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
+import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -18,6 +19,7 @@ public class FooterPage {
     }
 
     public boolean isBannerAfterLoginDisplayed(){
+        WaitForElement.waitUntilEmenentsVisable(bannerAfterLoginLogo);
         boolean isDisplayed = bannerAfterLoginLogo.isDisplayed();
         return isDisplayed;
     }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LandingPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LandingPage.java
@@ -1,6 +1,7 @@
 package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
+import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -10,11 +11,12 @@ public class LandingPage {
     @FindBy(css = "#Content a")
     private WebElement enterStoreLink;
 
-    public LandingPage(){
-       PageFactory.initElements(DriverManager.getWebDriver(),this);
+    public LandingPage() {
+        PageFactory.initElements(DriverManager.getWebDriver(), this);
     }
 
-    public void clickOnEnterStoreLink(){
-       enterStoreLink.click();
+    public void clickOnEnterStoreLink() {
+        WaitForElement.waitUntilElementsClicable(enterStoreLink);
+        enterStoreLink.click();
     }
 }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LoginPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LoginPage.java
@@ -1,6 +1,7 @@
 package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
+import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -30,12 +31,11 @@ public class LoginPage {
     }
 
     public void typeIntoUserNameField(String username) {
-        usernameField.clear();
+        WaitForElement.waitUntilEmenentsVisable(usernameField);
         usernameField.sendKeys(username);
     }
 
     public void typeIntoPasswordField(String password) {
-        passwordField.clear();
         passwordField.sendKeys(password);
     }
 
@@ -44,6 +44,7 @@ public class LoginPage {
     }
 
     public String getWarningMessage() {
+        WaitForElement.waitUntilEmenentsVisable(messageLabel);
         String warningText = messageLabel.getText();
         return warningText;
     }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/TopMenuPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/TopMenuPage.java
@@ -1,6 +1,7 @@
 package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
+import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -13,14 +14,15 @@ public class TopMenuPage {
     @FindBy(css = "#MenuContent a[href*='signonForm']")
     private WebElement signOnLink;
 
-    public TopMenuPage(){
+    public TopMenuPage() {
         PageFactory.initElements(DriverManager.getWebDriver(), this);
     }
 
     //  https://www.w3schools.com/cssref/css_selectors.asp
 //  #firstname 	Selects the element with id="firstname"
 // 	a[href*="w3schools"] 	Selects every <a> element whose href attribute value contains the substring "w3schools"
-    public void clickOnSignInLink(){
+    public void clickOnSignInLink() {
+        WaitForElement.waitUntilElementsClicable(signOnLink);
         signOnLink.click();
     }
 }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/waits/WaitForElement.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/waits/WaitForElement.java
@@ -1,0 +1,26 @@
+package JavaStartSeleniumRozdzial_9.waits;
+
+import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+
+public class WaitForElement {
+
+    private static WebDriverWait getWebDriverWait() {
+        return new WebDriverWait(DriverManager.getWebDriver(), Duration.ofSeconds(10));
+    }
+
+    public static void waitUntilEmenentsVisable(WebElement element) {
+        WebDriverWait webDriverWait = getWebDriverWait();
+        webDriverWait.until(ExpectedConditions.visibilityOf(element));
+    }
+
+    public static void waitUntilElementsClicable(WebElement element) {
+        WebDriverWait webDriverWait = getWebDriverWait();
+        webDriverWait.until(ExpectedConditions.elementToBeClickable(element));
+    }
+
+}


### PR DESCRIPTION
Explicit waity. Wrzucone do tylko niezbędnych metod. W klasie LoginPage użyte tylko do username ponieważ przed spisaniem loginu już nic nie powinno się ładować na stornie. A zbędne waity tylko niepotrzebnie spowalniają test